### PR TITLE
Add functionality for adding new exercises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0
+- Support adding new exercises
+
 ## 1.1.0
 - Can mark exercises as finished
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ryp-calculator",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Redux store, actions and reducers for a RYP calculator",
   "files": [
     "lib/"

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -25,3 +25,13 @@ export const exerciseFinished = (day, name) => (
         name,
     }
 );
+
+export const ADD_EXERCISE = 'ADD_EXERCISE';
+export const addExercise = (label, value, notes) => (
+    {
+        type: ADD_EXERCISE,
+        label,
+        value,
+        notes,
+    }
+);

--- a/src/reducers/days.js
+++ b/src/reducers/days.js
@@ -7,6 +7,8 @@ for (let i = 0, l = 18; i < l; i++) {
     days[i] = i + 1;
 }
 
+let customCounter = 1;
+
 export const defaultDays = days.map(day => {
     const formula = formulas[day - 1];
     return defaultExercises.map(exercise => ({
@@ -61,6 +63,22 @@ const exerciseFinished = (state, action) =>
         return day;
     });
 
+const addExercise = (state, { label, value, notes }) => {
+    const name = `custom_${customCounter++}`;
+
+    return state.map((day, idx) => {
+        const formula = formulas[idx];
+
+        return day.concat({
+            name,
+            notes,
+            label,
+            value: (value * formula.multiplier).toFixed(1),
+            finished: false,
+        });
+    });
+};
+
 export default (state = defaultDays, action) => {
     switch (action.type) {
         case actions.FIELD_CHANGE:
@@ -69,6 +87,8 @@ export default (state = defaultDays, action) => {
             return updateExerciseLabel(state, action);
         case actions.EXERCISE_FINISHED:
             return exerciseFinished(state, action);
+        case actions.ADD_EXERCISE:
+            return addExercise(state, action);
         default:
             return state;
     }

--- a/src/reducers/exercises.js
+++ b/src/reducers/exercises.js
@@ -52,29 +52,37 @@ export const defaultExercises = [
     },
 ];
 
-const updateExerciseValue = (state, action) => {
-    const nextState = Array.from(state);
-    return nextState.map(exercise => {
-        if (exercise.name === action.field) {
-            return { ...exercise, value: action.value };
+let customCounter = 1;
+
+const updateExerciseValue = (state, { field, value }) =>
+    state.map(exercise => {
+        if (exercise.name === field) {
+            return { ...exercise, value };
         }
         return exercise;
     });
-};
 
-const updateExerciseLabel = (state, action) => {
-    const nextState = Array.from(state);
-    return nextState.map(exercise => {
-        if (exercise.name === action.field) {
+const updateExerciseLabel = (state, { field, value, notes }) =>
+    state.map(exercise => {
+        if (exercise.name === field) {
             return {
                 ...exercise,
-                label: action.value,
-                notes: action.notes,
+                label: value,
+                notes,
             };
         }
         return exercise;
     });
-};
+
+const addExercise = (state, { label, value, notes }) =>
+    state.concat({
+        name: `custom_${customCounter++}`,
+        notes,
+        label,
+        value,
+        finished: false,
+    });
+
 
 export default (state = defaultExercises, action) => {
     switch (action.type) {
@@ -82,6 +90,8 @@ export default (state = defaultExercises, action) => {
             return updateExerciseValue(state, action);
         case actions.LABEL_CHANGE:
             return updateExerciseLabel(state, action);
+        case actions.ADD_EXERCISE:
+            return addExercise(state, action);
         default:
             return state;
     }

--- a/test/reducers/days.spec.js
+++ b/test/reducers/days.spec.js
@@ -1,16 +1,16 @@
 import reducer, { defaultDays } from '../../src/reducers/days';
 import formula from '../../src/formula';
 import {
+    addExercise,
+    exerciseFinished,
     fieldChange,
     labelChange,
-    exerciseFinished,
 } from '../../src/actions';
 
 describe('days reducer', () => {
 
     it('returns the default state', () => {
         const action = { type: 'UNKNOWN' };
-
         const state = reducer(undefined, action);
 
         expect(state).to.eql(defaultDays);
@@ -19,7 +19,6 @@ describe('days reducer', () => {
     describe('when marking as finished', () => {
         it('marks the given exercise as finished', () => {
             const action = exerciseFinished(5, 'triceps');
-
             const state = reducer(undefined, action);
 
             const exercise = state[5].find(
@@ -31,7 +30,6 @@ describe('days reducer', () => {
 
         it('does not mark other exercises as finished', () => {
             const action = exerciseFinished(5, 'triceps');
-
             const state = reducer(undefined, action);
 
             const exercise = state[4].find(
@@ -45,7 +43,6 @@ describe('days reducer', () => {
     describe('when updating', () => {
         it('updates all days when a value is changed', () => {
             const action = fieldChange('arnold', 20);
-
             const state = reducer(undefined, action);
 
             const arnoldDays = state.map(day =>
@@ -65,7 +62,6 @@ describe('days reducer', () => {
 
         it('does not update values for other exercises', () => {
             const action = fieldChange('arnold', 20);
-
             const state = reducer(undefined, action);
 
             const bicepsDays = state.map(day =>
@@ -73,10 +69,6 @@ describe('days reducer', () => {
             );
 
             bicepsDays.forEach((day, idx) => {
-                const multiplier = formula.find(
-                    f => f.day === idx + 1
-                ).multiplier;
-
                 const expectedValue = defaultDays[idx].find(
                     exercise => exercise.name === 'biceps'
                 ).value;
@@ -87,7 +79,6 @@ describe('days reducer', () => {
 
         it('updates all days when a label is changed', () => {
             const action = labelChange('abs', 'Crunch');
-
             const state = reducer(undefined, action);
 
             const absDays = state.map(day =>
@@ -101,7 +92,6 @@ describe('days reducer', () => {
 
         it('does not update labels for other exercises', () => {
             const action = labelChange('abs', 'Crunch');
-
             const state = reducer(undefined, action);
 
             const squatDays = state.map(day =>
@@ -111,6 +101,43 @@ describe('days reducer', () => {
             squatDays.forEach(exercise =>
                 expect(exercise.label).to.equal('Knebøy')
             );
+        });
+    });
+
+    describe('When adding exercises', () => {
+        it('adds the new exercise to every day', () => {
+            const action = addExercise('Markløft', 70, '');
+            const state = reducer(undefined, action);
+
+            const deadliftDays = state.map(day =>
+                day.find(exercise => exercise.label === 'Markløft')
+            );
+
+            deadliftDays.forEach((exercise, idx) => {
+                const multiplier = formula.find(
+                    f => f.day === idx + 1
+                ).multiplier;
+
+                const expectedValue = (70 * multiplier).toFixed(1);
+
+                expect(exercise.label).to.equal('Markløft')
+                expect(exercise.value).to.equal(expectedValue);
+                expect(exercise.notes).to.equal('');
+                expect(exercise.finished).to.equal(false);
+            });
+        });
+
+        it('uses the same name for all the days', () => {
+            const action = addExercise('Markløft', 70, '');
+            const state = reducer(undefined, action);
+
+            const deadliftDays = state.map(day =>
+                day.find(exercise => exercise.label === 'Markløft')
+            );
+
+            const unique = new Set(deadliftDays.map(d => d.name));
+
+            expect(unique.size).to.be(1);
         });
     });
 });

--- a/test/reducers/exercises.spec.js
+++ b/test/reducers/exercises.spec.js
@@ -1,11 +1,14 @@
 import reducer, { defaultExercises } from '../../src/reducers/exercises';
-import { fieldChange, labelChange } from '../../src/actions';
+import {
+    addExercise,
+    fieldChange,
+    labelChange,
+} from '../../src/actions';
 
 describe('exercises reducer', () => {
 
     it('returns the default state', () => {
         const action = { type: 'UNKNOWN' };
-
         const state = reducer(undefined, action);
 
         expect(state).to.eql(defaultExercises);
@@ -14,10 +17,10 @@ describe('exercises reducer', () => {
     describe('when updating', () => {
         it('updates the value of a specified exercise', () => {
             const action = fieldChange('squats', 42);
-            const nextState = reducer(defaultExercises, action);
+            const state = reducer(defaultExercises, action);
 
-            const squats = nextState.find(e => e.name === 'squats');
-            const benchpress = nextState.find(e => e.name === 'benchpress');
+            const squats = state.find(e => e.name === 'squats');
+            const benchpress = state.find(e => e.name === 'benchpress');
             const defaultBenchpress = defaultExercises.find(e => e.name === 'benchpress');
 
             expect(squats.value).to.be(42);
@@ -26,15 +29,42 @@ describe('exercises reducer', () => {
 
         it('updates label and notes of a specified exercise', () => {
             const action = labelChange('row', 'Stående roing', 'Stang');
-            const nextState = reducer(defaultExercises, action);
+            const state = reducer(defaultExercises, action);
 
-            const row = nextState.find(e => e.name === 'row');
-            const squats = nextState.find(e => e.name === 'squats');
+            const row = state.find(e => e.name === 'row');
+            const squats = state.find(e => e.name === 'squats');
 
             expect(row.label).to.equal('Stående roing');
             expect(row.notes).to.equal('Stang');
             expect(squats.label).to.equal('Knebøy');
             expect(squats.notes).to.equal('');
+        });
+    });
+
+    describe('When adding exercises', () => {
+        it('adds the new exercise to the list', () => {
+            const action = addExercise('Markløft', 70, 'stang');
+            const state = reducer(undefined, action);
+
+            const deadlift = state.find(e => e.name === 'custom_1');
+
+            expect(deadlift).to.be.an('object');
+            expect(deadlift.label).to.equal('Markløft');
+            expect(deadlift.value).to.equal(70);
+            expect(deadlift.notes).to.equal('stang');
+            expect(deadlift.finished).to.be(false);
+        });
+
+        it('gives each exercise a unique name', () => {
+            const action_1 = addExercise('Markløft', 70, 'stang');
+            const action_2 = addExercise('Benkpress', 60, 'stang');
+
+            const state_1 = reducer(undefined, action_1);
+            const state_2 = reducer(state_1, action_2);
+
+            const unique = new Set(state_2.map(s => s.name));
+
+            expect(unique.size).to.equal(state_2.length);
         });
     });
 });


### PR DESCRIPTION
It's a bit problematic that logic for updating the list is now
duplicated between the reducers. Ideally the "days" reducer should
fire after the "exercises" reducer and actually work on that
data. Going to have to figure out a way to do that.