### PR TITLE
Use Immutable.js instead of javascript objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.0
+- Use [immutable.js](https://facebook.github.io/immutable-js/) instead of plain javascript objects. Potentially breaking change is that Arrays are now Lists and elements can't be read using `list[idx]`. The way to get an element out of an Immutable List is `list.get(idx)`.
+
 ## 1.2.0
 - Support adding new exercises
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ryp-calculator",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Redux store, actions and reducers for a RYP calculator",
   "files": [
     "lib/"
@@ -51,6 +51,7 @@
   "dependencies": {
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "immutable": "^3.8.1",
     "react-router-redux": "^4.0.5",
     "redux": "^3.5.2",
     "redux-logger": "^2.6.1",

--- a/src/reducers/days.js
+++ b/src/reducers/days.js
@@ -1,3 +1,5 @@
+import Immutable from 'immutable';
+
 import * as actions from '../actions';
 import { defaultExercises } from './exercises';
 import formulas from '../formula';
@@ -9,27 +11,25 @@ for (let i = 0, l = 18; i < l; i++) {
 
 let customCounter = 1;
 
-export const defaultDays = days.map((day) => {
+export const defaultDays = Immutable.List.of(...days.map((day) => {
     const formula = formulas[day - 1];
-    return defaultExercises.map(exercise => ({
-        ...exercise,
+    return defaultExercises.map(exercise => exercise.merge({
         title: formula.title,
         value: (exercise.value * formula.multiplier).toFixed(1),
         sets: formula.sets[exercise.name],
     }));
-});
+}));
 
 const updateExerciseValue = (state, action) =>
     state.map((day, i) => {
         const formula = formulas[i];
         return day.map((exercise) => {
             if (exercise.name === action.field) {
-                return {
-                    ...exercise,
+                return exercise.merge({
                     title: formula.title,
                     value: (action.value * formula.multiplier).toFixed(1),
                     sets: formula.sets[exercise.name],
-                };
+                });
             }
             return exercise;
         });
@@ -39,11 +39,10 @@ const updateExerciseLabel = (state, action) =>
     state.map(day =>
         day.map((exercise) => {
             if (exercise.name === action.field) {
-                return {
-                    ...exercise,
-                    notes: action.notes,
+                return exercise.merge({
                     label: action.value,
-                };
+                    notes: action.notes,
+                });
             }
             return exercise;
         })
@@ -53,11 +52,10 @@ const exerciseFinished = (state, action) =>
     state.map((day, index) => {
         if (action.day === index) {
             return day.map((exercise) => {
-                const newExercise = { ...exercise };
                 if (exercise.name === action.name) {
-                    newExercise.finished = true;
+                    return exercise.set('finished', true);
                 }
-                return newExercise;
+                return exercise;
             });
         }
         return day;

--- a/src/reducers/exercises.js
+++ b/src/reducers/exercises.js
@@ -1,63 +1,77 @@
+import Immutable from 'immutable';
+
 import * as actions from '../actions';
 
-export const defaultExercises = [
-    {
+/* eslint-disable new-cap */
+const ExerciseRecord = Immutable.Record({
+    name: null,
+    notes: null,
+    label: null,
+    title: null,
+    value: 0,
+    finished: false,
+    sets: {},
+});
+/* eslint-enable new-cap */
+
+export const defaultExercises = Immutable.List.of(
+    new ExerciseRecord({
         name: 'squats',
         notes: '',
         label: 'Knebøy',
         value: 70,
         finished: false,
-    },
-    {
+    }),
+    new ExerciseRecord({
         name: 'benchpress',
         notes: '',
         label: 'Skråbenk, manualer',
         value: 22.5,
         finished: false,
-    },
-    {
+    }),
+    new ExerciseRecord({
         name: 'row',
         notes: '',
         label: 'Nedtrekk',
         value: 50,
         finished: false,
-    },
-    {
+    }),
+    new ExerciseRecord({
         name: 'arnold',
         notes: '',
         label: 'Arnoldpress',
         value: 15,
         finished: false,
-    },
-    {
+    }),
+    new ExerciseRecord({
         name: 'biceps',
         notes: '',
         label: 'Bicepscurl',
         value: 12.5,
         finished: false,
-    },
-    {
+    }),
+    new ExerciseRecord({
         name: 'triceps',
         notes: 'Over hodet',
         label: 'Tricepspress',
         value: 30,
         finished: false,
-    },
-    {
+    }),
+    new ExerciseRecord({
         name: 'abs',
         notes: '',
         label: 'Mage',
         value: 30,
         finished: false,
-    },
-];
+    }),
+);
 
 let customCounter = 1;
 
 const updateExerciseValue = (state, { field, value }) =>
     state.map((exercise) => {
         if (exercise.name === field) {
-            return { ...exercise, value };
+            return exercise.set('value', value);
         }
         return exercise;
     });
@@ -65,11 +79,10 @@ const updateExerciseValue = (state, { field, value }) =>
 const updateExerciseLabel = (state, { field, value, notes }) =>
     state.map((exercise) => {
         if (exercise.name === field) {
-            return {
-                ...exercise,
+            return exercise.merge({
                 label: value,
                 notes,
-            };
+            });
         }
         return exercise;
     });

--- a/test/reducers/days.spec.js
+++ b/test/reducers/days.spec.js
@@ -20,7 +20,7 @@ describe('days reducer', () => {
             const action = exerciseFinished(5, 'triceps');
             const state = reducer(undefined, action);
 
-            const exercise = state[5].find(
+            const exercise = state.get(5).find(
                 e => e.name === 'triceps'
             );
 
@@ -31,7 +31,7 @@ describe('days reducer', () => {
             const action = exerciseFinished(5, 'triceps');
             const state = reducer(undefined, action);
 
-            const exercise = state[4].find(
+            const exercise = state.get(4).find(
                 e => e.name === 'triceps'
             );
 
@@ -55,7 +55,7 @@ describe('days reducer', () => {
 
                 const expectedValue = (20 * multiplier).toFixed(1);
 
-                expect(arnoldDays[idx].value).to.be(expectedValue);
+                expect(arnoldDays.get(idx).value).to.be(expectedValue);
             });
         });
 
@@ -68,11 +68,11 @@ describe('days reducer', () => {
             );
 
             bicepsDays.forEach((day, idx) => {
-                const expectedValue = defaultDays[idx].find(
+                const expectedValue = defaultDays.get(idx).find(
                     exercise => exercise.name === 'biceps'
                 ).value;
 
-                expect(bicepsDays[idx].value).to.be(expectedValue);
+                expect(bicepsDays.get(idx).value).to.be(expectedValue);
             });
         });
 

--- a/test/reducers/exercises.spec.js
+++ b/test/reducers/exercises.spec.js
@@ -32,7 +32,6 @@ describe('exercises reducer', () => {
 
             const row = state.find(e => e.name === 'row');
             const squats = state.find(e => e.name === 'squats');
-
             expect(row.label).to.equal('Stående roing');
             expect(row.notes).to.equal('Stang');
             expect(squats.label).to.equal('Knebøy');
@@ -63,7 +62,7 @@ describe('exercises reducer', () => {
 
             const unique = new Set(state2.map(s => s.name));
 
-            expect(unique.size).to.equal(state2.length);
+            expect(unique.size).to.equal(state2.size);
         });
     });
 });


### PR DESCRIPTION
Potentially breaking change is that Arrays are now Lists and
elements can't be read using `list[idx]`. The way to get an
element out of an Immutable List is `list.get(idx)`.
In addition to that, Immutable List does not have
a `.length` property but a `.size`.